### PR TITLE
Fix the documents list page

### DIFF
--- a/src/main/java/com/gitblit/wicket/pages/DocsPage.java
+++ b/src/main/java/com/gitblit/wicket/pages/DocsPage.java
@@ -65,7 +65,7 @@ public class DocsPage extends RepositoryPage {
 		final String commitId = getBestCommitId(head);
 
 		List<String> extensions = processor.getAllExtensions();
-		List<PathModel> paths = JGitUtils.getDocuments(r, extensions);
+		List<PathModel> paths = JGitUtils.getDocuments(r, extensions, objectId);
 
 		List<MarkupDocument> roots = processor.getRootDocs(r, repositoryName, commitId);
 		Fragment fragment = null;


### PR DESCRIPTION
- The documents list page wasn't loading from correct branch, only from master. I added the objectId param to load the documents from current selected branch.